### PR TITLE
make script more robust against similar usernames

### DIFF
--- a/svn-rename-author
+++ b/svn-rename-author
@@ -12,7 +12,7 @@ echo -n "Are you sure you wish to change the authour of all commits made by \"$1
 read DOIT
 
 if [ "$DOIT" == "y" -o "$DOIT" == "Y" ]; then
-  for f in `svn log | grep "^r[0-9]* | $1" | cut -c 2- | awk '{print $1}'`
+  for f in `svn log | grep "^r[0-9]* | $1 |" | cut -c 2- | awk '{print $1}'`
   do
     svn propset --revprop -r $f svn:author $2
   done


### PR DESCRIPTION
Changing from the name 'john' to a new one used to also change all commits made by the user 'johnathan' to the new name. This is because grep finds substrings, not single words.
With this change, only exact matches are found.